### PR TITLE
Add details to HTTP 401 and 403 errors

### DIFF
--- a/validatetoken.go
+++ b/validatetoken.go
@@ -100,7 +100,7 @@ func (azureJwt *AzureJwtPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 		switch err.Error() {
 		case "no authorization header":
 			errMsg = "No token provided. Please use Authorization header to pass a valid token."
-		case "no bearer token":
+		case "not bearer auth scheme":
 			errMsg = "Token provided on Authorization header is not a bearer token. Please provide a valid bearer token."
 		case "invalid token format":
 			errMsg = "The format of the bearer token provided on Authorization header is invalid. Please provide a valid bearer token."
@@ -192,8 +192,8 @@ func (azureJwt *AzureJwtPlugin) ExtractToken(request *http.Request) (*AzureJwt, 
 	}
 	auth := authHeader[0]
 	if !strings.HasPrefix(auth, "Bearer ") {
-		fmt.Println("No bearer token")
-		return nil, errors.New("no bearer token")
+		fmt.Println("not bearer auth scheme")
+		return nil, errors.New("not bearer auth scheme")
 	}
 	parts := strings.Split(auth[7:], ".")
 	if len(parts) != 3 {

--- a/validatetoken.go
+++ b/validatetoken.go
@@ -98,12 +98,14 @@ func (azureJwt *AzureJwtPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 		errMsg := ""
 
 		switch err.Error() {
-		case "no_header_token":
+		case "no header token":
 			errMsg = "No token provided. Please use Authorization header to pass a valid token."
-		case "no_bearer_token":
+		case "no bearer token":
 			errMsg = "Token provided on Authorization header is not a bearer token. Please provide a valid bearer token."
-		case "invalid_token_format":
+		case "invalid token format":
 			errMsg = "The format of the bearer token provided on Authorization header is invalid. Please provide a valid bearer token."
+		case "invalid token":
+			errMsg = "The token provided is invalid. Please provide a valid bearer token."
 		}
 
 		http.Error(rw, errMsg, http.StatusUnauthorized)
@@ -186,17 +188,17 @@ func (azureJwt *AzureJwtPlugin) ExtractToken(request *http.Request) (*AzureJwt, 
 	authHeader, ok := request.Header["Authorization"]
 	if !ok {
 		fmt.Println("No header token")
-		return nil, errors.New("no_header_token")
+		return nil, errors.New("no header token")
 	}
 	auth := authHeader[0]
 	if !strings.HasPrefix(auth, "Bearer ") {
 		fmt.Println("No bearer token")
-		return nil, errors.New("no_bearer_token")
+		return nil, errors.New("no bearer token")
 	}
 	parts := strings.Split(auth[7:], ".")
 	if len(parts) != 3 {
 		fmt.Println("invalid token format")
-		return nil, errors.New("invalid_token_format")
+		return nil, errors.New("invalid token format")
 	}
 
 	header, err := base64.RawURLEncoding.DecodeString(parts[0])

--- a/validatetoken.go
+++ b/validatetoken.go
@@ -95,13 +95,25 @@ func (azureJwt *AzureJwtPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 			LoggerDEBUG.Println(valerr)
 		}
 	} else {
+		errMsg := ""
+
+		switch err.Error() {
+		case "no_header_token":
+			errMsg = "No token provided. Please use Authorization header to pass a valid token."
+		case "no_bearer_token":
+			errMsg = "Token provided on Authorization header is not a bearer token. Please provide a valid bearer token."
+		case "invalid_token_format":
+			errMsg = "The format of the bearer token provided on Authorization header is invalid. Please provide a valid bearer token."
+		}
+
+		http.Error(rw, errMsg, http.StatusUnauthorized)
 		LoggerDEBUG.Println(err)
 	}
 
 	if tokenValid {
 		azureJwt.next.ServeHTTP(rw, req)
 	} else {
-		http.Error(rw, "Not allowed", http.StatusForbidden)
+		http.Error(rw, "The token you provided is not valid. Please provide a valid token.", http.StatusForbidden)
 	}
 }
 
@@ -174,17 +186,17 @@ func (azureJwt *AzureJwtPlugin) ExtractToken(request *http.Request) (*AzureJwt, 
 	authHeader, ok := request.Header["Authorization"]
 	if !ok {
 		fmt.Println("No header token")
-		return nil, errors.New("no token")
+		return nil, errors.New("no_header_token")
 	}
 	auth := authHeader[0]
 	if !strings.HasPrefix(auth, "Bearer ") {
 		fmt.Println("No bearer token")
-		return nil, errors.New("no token")
+		return nil, errors.New("no_bearer_token")
 	}
 	parts := strings.Split(auth[7:], ".")
 	if len(parts) != 3 {
 		fmt.Println("invalid token format")
-		return nil, errors.New("no token")
+		return nil, errors.New("invalid_token_format")
 	}
 
 	header, err := base64.RawURLEncoding.DecodeString(parts[0])

--- a/validatetoken.go
+++ b/validatetoken.go
@@ -98,7 +98,7 @@ func (azureJwt *AzureJwtPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 		errMsg := ""
 
 		switch err.Error() {
-		case "no header token":
+		case "no authorization header":
 			errMsg = "No token provided. Please use Authorization header to pass a valid token."
 		case "no bearer token":
 			errMsg = "Token provided on Authorization header is not a bearer token. Please provide a valid bearer token."
@@ -187,8 +187,8 @@ func verifyAndSetPublicKey(publicKey string) error {
 func (azureJwt *AzureJwtPlugin) ExtractToken(request *http.Request) (*AzureJwt, error) {
 	authHeader, ok := request.Header["Authorization"]
 	if !ok {
-		fmt.Println("No header token")
-		return nil, errors.New("no header token")
+		fmt.Println("No authorization header present")
+		return nil, errors.New("no authorization header")
 	}
 	auth := authHeader[0]
 	if !strings.HasPrefix(auth, "Bearer ") {

--- a/validatetoken_test.go
+++ b/validatetoken_test.go
@@ -104,7 +104,7 @@ func TestNotBearerToken(t *testing.T) {
 
 	extractedToken, err := createRequestWithAuthorizationHeaderButNotBearerToken(t, azureJwtPlugin, invalidToken)
 
-	assert.Equal(t, err.Error(), "no bearer token")
+	assert.Equal(t, err.Error(), "not bearer auth scheme")
 	assert.Nil(t, extractedToken)
 }
 

--- a/validatetoken_test.go
+++ b/validatetoken_test.go
@@ -84,9 +84,9 @@ func TestMissingAuthorizationHeaderToken(t *testing.T) {
 		},
 	}
 
-	extractedToken, err := createUnauthorizedHeaderMissingRequest(t, azureJwtPlugin)
+	extractedToken, err := createRequestWithoutAuthorizationHeader(t, azureJwtPlugin)
 
-	assert.Equal(t, err.Error(), "no header token")
+	assert.Equal(t, err.Error(), "no authorization header")
 	assert.Nil(t, extractedToken)
 }
 
@@ -102,7 +102,7 @@ func TestNotBearerToken(t *testing.T) {
 	expiresAt := time.Now().Add(-time.Hour)
 	invalidToken, _ := generateTestToken(expiresAt, azureJwtPlugin.config.Roles, azureJwtPlugin.config.Audience, azureJwtPlugin.config.Issuer)
 
-	extractedToken, err := createUnauthorizedNotBearerTokenRequest(t, azureJwtPlugin, invalidToken)
+	extractedToken, err := createRequestWithAuthorizationHeaderButNotBearerToken(t, azureJwtPlugin, invalidToken)
 
 	assert.Equal(t, err.Error(), "no bearer token")
 	assert.Nil(t, extractedToken)
@@ -118,7 +118,7 @@ func TestInvalidTokenFormat(t *testing.T) {
 	}
 
 	tokenWithInvalidFormat := "some_format"
-	extractedToken, err := createUnauthorizedInvalidBearerTokenRequest(t, azureJwtPlugin, tokenWithInvalidFormat)
+	extractedToken, err := createRequestWithInvalidBearerTokenFormat(t, azureJwtPlugin, tokenWithInvalidFormat)
 
 	assert.Equal(t, err.Error(), "invalid token format")
 	assert.Nil(t, extractedToken)
@@ -252,14 +252,14 @@ func createRequestAndValidateToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, 
 	return extractedToken, err
 }
 
-func createUnauthorizedHeaderMissingRequest(t *testing.T, azureJwtPlugin AzureJwtPlugin) (*AzureJwt, error) {
+func createRequestWithoutAuthorizationHeader(t *testing.T, azureJwtPlugin AzureJwtPlugin) (*AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)
 
 	return extractedToken, err
 }
 
-func createUnauthorizedNotBearerTokenRequest(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
+func createRequestWithAuthorizationHeaderButNotBearerToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	request.Header.Set("Authorization", token)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)
@@ -267,7 +267,7 @@ func createUnauthorizedNotBearerTokenRequest(t *testing.T, azureJwtPlugin AzureJ
 	return extractedToken, err
 }
 
-func createUnauthorizedInvalidBearerTokenRequest(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
+func createRequestWithInvalidBearerTokenFormat(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	request.Header.Set("Authorization", "Bearer "+token)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)


### PR DESCRIPTION
**Context:** 
When getting a HTTP 401 or 403 errors, the messages are not very clear and are over simplified. 

This PR aims to solve that by adding more information to HTTP 401 and 403 error messages. 

**What is included in the PR**
- New logic that differentiates between different errors when HTTP status code is 403
- More descriptive error message on HTTP 401
- New tests to validate new logic