### PR TITLE
ci: :construction_worker: Add pre-commit config & helper makefile for…

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,13 +19,26 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.24.3
 
     - name: Build
       run: go build -v ./...
 
+    # FIXME: uncomment and fix issues
+    # - name: Staticcheck
+    #   run: make ci_staticcheck
+
+    - name: GoVet
+      run: go vet ./...
+
+    # FIXME: uncomment and fix issues
+    # - name: Run Gosec Security Scanner
+    #   uses: securego/gosec@2.22.4
+    #   with:
+    #     args: ./...
+
     - name: Test
-      run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
-    
+      run: make ci_test
+
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 .dccache
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Pre-commit generated files
+
+# unit tests
+**/results_junitxml_gosec.xml
+
+/.tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# See http://pre-commit.com for more information
+# See http://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: check-added-large-files
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1
+    hooks:
+    - id: my-cmd-mod
+      name: go-test
+      alias: go-test
+      args: [ make, ci_test, '--hook:env:_GO_TEST_SHORT=${GO_TEST_SHORT}' ]
+    - id: go-vet-mod
+    # FIXME: uncomment and fix issues
+    # - id: go-sec-mod
+    #   args: [ -fmt=junit-xml, -out=results_junitxml_gosec.xml, -track-suppressions ]
+    # - id: go-staticcheck-mod
+    #   args: [-checks, "all, -ST1000, -ST1001, -ST1003, -ST1016, -ST1020, -ST1021, -ST1022"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+ifndef $(GOPATH)
+    GOPATH=$(shell go env GOPATH)
+    export GOPATH
+endif
+
+# Alias for tools
+tools: .tools
+.PHONY: tools
+
+.tools:
+	curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(GOPATH)/bin v2.22.4
+	go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
+	touch .tools
+
+clean_tools:
+	rm -f .tools
+.PHONY: clean_tools
+
+run_tests: tools
+	go test ./... -v
+
+run_tests_short: tools
+	go test ./... -v -short
+
+ci_test: tools
+	go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
+
+ci_staticcheck: tools
+	staticcheck -checks "all, -ST1000, -ST1001, -ST1003, -ST1016, -ST1020, -ST1021, -ST1022" ./...
+
+race: tools
+	CGO_ENABLED=1 go test -v -race $(_GO_TEST_SHORT) ./...
+
+go_vuln:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	govulncheck ./...


### PR DESCRIPTION
… dev use. Update go github action to run additional checks

* Makefile can be used by devs/CI to install correct version of tools
* go sec & staticcheck commented out for now until underlying issues fixed later
* Bumping go version to 1.24.3 in github action so staticcheck is compatible