### PR TITLE
ci: :rotating_light: Enable staticcheck in pre-commit & github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,9 +24,8 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    # FIXME: uncomment and fix issues
-    # - name: Staticcheck
-    #   run: make ci_staticcheck
+    - name: Staticcheck
+      run: make ci_staticcheck
 
     - name: GoVet
       run: go vet ./...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
     # FIXME: uncomment and fix issues
     # - id: go-sec-mod
     #   args: [ -fmt=junit-xml, -out=results_junitxml_gosec.xml, -track-suppressions ]
-    # - id: go-staticcheck-mod
-    #   args: [-checks, "all, -ST1000, -ST1001, -ST1003, -ST1016, -ST1020, -ST1021, -ST1022"]
+    - id: go-staticcheck-mod
+      args: [-checks, "all, -ST1000, -ST1001, -ST1003, -ST1016, -ST1020, -ST1021, -ST1022"]

--- a/validatetoken.go
+++ b/validatetoken.go
@@ -325,7 +325,7 @@ func (azureJwt *AzureJwtPlugin) validateClaims(parsedClaims *Claims) error {
 
 	if parsedClaims.Roles != nil {
 		if len(azureJwt.config.Roles) > 0 {
-			var allRolesValid bool = true
+			var allRolesValid = true
 			if !azureJwt.config.MatchAllRoles {
 				allRolesValid = false
 			}

--- a/validatetoken_test.go
+++ b/validatetoken_test.go
@@ -504,6 +504,7 @@ func generateTestToken(expiresAt time.Time, roles []string, audience string, iss
 
 	testClaims := &JwtClaim{
 		Roles: roles,
+		//lint:ignore SA1019 FIXME at a later date. Use RegisteredClaims: https://pkg.go.dev/github.com/golang-jwt/jwt/v4@v4.4.2#example-NewWithClaims-CustomClaimsType
 		StandardClaims: jwt.StandardClaims{
 			Audience:  audience,
 			Issuer:    issuer,


### PR DESCRIPTION
* Fixes "validatetoken.go:328:22: should omit type bool from declaration; it will be inferred from the right-hand side (ST1023)"
* We ignore SA1019 deprecated jwt.StandardClaims for now as requires further refactoring and tests