### PR TITLE
Alex/get keys on start and return error

### DIFF
--- a/validatetoken.go
+++ b/validatetoken.go
@@ -82,6 +82,15 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		},
 	}
 
+	// Set up the initial public keys before we start
+	// Ensure we return an error if we fail
+	// This will disable the plugin & any routes dependent on the plugin: https://github.com/traefik/plugindemo?tab=readme-ov-file#usage
+	err := plugin.GetPublicKeys(config)
+	if err != nil {
+		LoggerWARN.Println("failed to start azadjwtvalidation plugin! Disabling plugin")
+		return nil, err
+	}
+
 	go plugin.scheduleUpdateKeys(config)
 
 	return plugin, nil

--- a/validatetoken.go
+++ b/validatetoken.go
@@ -138,6 +138,9 @@ func (azureJwt *AzureJwtPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 }
 
 func (azureJwt *AzureJwtPlugin) scheduleUpdateKeys(config *Config) {
+	// FIXME: pass context here so we can check Done channel
+	// FIXME: 24 hours frequency is probably ok: https://learn.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#validate-signature
+	// FIXME: handle errors correctly
 	for {
 		_ = azureJwt.GetPublicKeys(config)
 		time.Sleep(15 * time.Minute)

--- a/validatetoken.go
+++ b/validatetoken.go
@@ -93,6 +93,8 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 
 	go plugin.scheduleUpdateKeys(config)
 
+	LoggerINFO.Println("azadjwtvalidation plugin started")
+
 	return plugin, nil
 }
 


### PR DESCRIPTION
Ensure we set up initial public keys before we start the plugin

    * We need to ensure we have public keys before any traffic is received
    * Ensure we return an error to disable the plugin if we can't set up public keys