### PR TITLE
Alex/refactor azadjwtvalidation validator

### DIFF
--- a/internal/azurejwtvalidator/validator.go
+++ b/internal/azurejwtvalidator/validator.go
@@ -1,0 +1,19 @@
+package azurejwtvalidator
+
+import (
+	"crypto/rsa"
+	"net/http"
+)
+
+type AzureJwtValidator struct {
+	client *http.Client
+	// Public keys: set if we pass a PublicKey in our config or retrieved via the JWKs url
+	rsakeys map[string]*rsa.PublicKey
+}
+
+func NewAzureJwtValidator(client *http.Client) *AzureJwtValidator {
+	return &AzureJwtValidator{
+		client:  client,
+		rsakeys: make(map[string]*rsa.PublicKey),
+	}
+}

--- a/internal/azurejwtvalidator/validator_test.go
+++ b/internal/azurejwtvalidator/validator_test.go
@@ -1,0 +1,21 @@
+package azurejwtvalidator
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAzureJwtValidator(t *testing.T) {
+	t.Run("expect non nil rsakeys", func(t *testing.T) {
+		azureJwtValidator := NewAzureJwtValidator(http.DefaultClient)
+		assert.NotNil(t, azureJwtValidator.rsakeys)
+	})
+
+	t.Run("expect our client to be set", func(t *testing.T) {
+		client := http.DefaultClient
+		azureJwtValidator := NewAzureJwtValidator(client)
+		assert.Equal(t, client, azureJwtValidator.client)
+	})
+}

--- a/internal/jwtmodels/claims.go
+++ b/internal/jwtmodels/claims.go
@@ -5,20 +5,6 @@ import (
 	"log"
 )
 
-type AzureJwt struct {
-	Header     AzureJwtHeader
-	Payload    Claims
-	Signature  []byte
-	RawToken   []byte
-	RawPayload []byte
-}
-
-type AzureJwtHeader struct {
-	Alg string `json:"alg"`
-	Kid string `json:"kid"`
-	Typ string `json:"typ"`
-}
-
 type Claims struct {
 	Iat   json.Number `json:"iat"`
 	Exp   json.Number `json:"exp"`
@@ -26,18 +12,6 @@ type Claims struct {
 	Aud   string      `json:"aud"`
 	Sub   string      `json:"sub"`
 	Roles []string    `json:"roles"`
-}
-
-type JWK struct {
-	Kid string `json:"kid"`
-	Kty string `json:"kty"`
-	Use string `json:"use"`
-	N   string `json:"n"`
-	E   string `json:"e"`
-}
-
-type JWKSet struct {
-	Keys []JWK `json:"keys"`
 }
 
 func (claims *Claims) IsValidForRole(configRole string, debugLogger *log.Logger) bool {

--- a/internal/jwtmodels/jwk.go
+++ b/internal/jwtmodels/jwk.go
@@ -1,0 +1,13 @@
+package jwtmodels
+
+type JWK struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type JWKSet struct {
+	Keys []JWK `json:"keys"`
+}

--- a/internal/jwtmodels/jwt-models.go
+++ b/internal/jwtmodels/jwt-models.go
@@ -1,7 +1,8 @@
-package azadjwtvalidation
+package jwtmodels
 
 import (
 	"encoding/json"
+	"log"
 )
 
 type AzureJwt struct {
@@ -37,4 +38,17 @@ type JWK struct {
 
 type JWKSet struct {
 	Keys []JWK `json:"keys"`
+}
+
+func (claims *Claims) IsValidForRole(configRole string, debugLogger *log.Logger) bool {
+	for _, parsedRole := range claims.Roles {
+		if parsedRole == configRole {
+			debugLogger.Println("Match:", parsedRole, configRole)
+			return true
+		} else {
+			debugLogger.Println("No match:", parsedRole, configRole)
+		}
+	}
+
+	return false
 }

--- a/internal/jwtmodels/jwt.go
+++ b/internal/jwtmodels/jwt.go
@@ -1,0 +1,17 @@
+package jwtmodels
+
+// FIXME: use proper golang-jwt package
+
+type AzureJwt struct {
+	Header     AzureJwtHeader
+	Payload    Claims
+	Signature  []byte
+	RawToken   []byte
+	RawPayload []byte
+}
+
+type AzureJwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+	Typ string `json:"typ"`
+}

--- a/validatetoken_test.go
+++ b/validatetoken_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/music-tribe/azadjwtvalidation/internal/jwtmodels"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -442,7 +443,7 @@ func TestHttpErrorLoggingWithLogHeaderEnabled(t *testing.T) {
 	assert.Contains(t, buf.String(), "\"Url\":\"/testtoken\"")
 }
 
-func createRequestAndValidateToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, publicKey *rsa.PublicKey, token string) (*AzureJwt, error) {
+func createRequestAndValidateToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, publicKey *rsa.PublicKey, token string) (*jwtmodels.AzureJwt, error) {
 	err := azureJwtPlugin.GetPublicKeys(&Config{
 		PublicKey: string(PublicKeyToBytes(publicKey)),
 		KeysUrl:   azureJwtPlugin.config.KeysUrl,
@@ -462,7 +463,7 @@ func createRequestAndValidateToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, 
 	return extractedToken, err
 }
 
-func createRequestAndValidateTokenWithNoPublicKeys(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
+func createRequestAndValidateTokenWithNoPublicKeys(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*jwtmodels.AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	request.Header.Set("Authorization", "Bearer "+token)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)
@@ -473,14 +474,14 @@ func createRequestAndValidateTokenWithNoPublicKeys(t *testing.T, azureJwtPlugin 
 	return extractedToken, err
 }
 
-func createRequestWithoutAuthorizationHeader(t *testing.T, azureJwtPlugin AzureJwtPlugin) (*AzureJwt, error) {
+func createRequestWithoutAuthorizationHeader(t *testing.T, azureJwtPlugin AzureJwtPlugin) (*jwtmodels.AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)
 
 	return extractedToken, err
 }
 
-func createRequestWithAuthorizationHeaderButNotBearerToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
+func createRequestWithAuthorizationHeaderButNotBearerToken(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*jwtmodels.AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	request.Header.Set("Authorization", token)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)
@@ -488,7 +489,7 @@ func createRequestWithAuthorizationHeaderButNotBearerToken(t *testing.T, azureJw
 	return extractedToken, err
 }
 
-func createRequestWithInvalidBearerTokenFormat(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*AzureJwt, error) {
+func createRequestWithInvalidBearerTokenFormat(t *testing.T, azureJwtPlugin AzureJwtPlugin, token string) (*jwtmodels.AzureJwt, error) {
 	request := httptest.NewRequest("GET", "/testtoken", nil)
 	request.Header.Set("Authorization", "Bearer "+token)
 	extractedToken, err := azureJwtPlugin.ExtractToken(request)


### PR DESCRIPTION
Make a start on splitting out the plugin from the jwt validation

New internal package for the validator which owns the public rsakeys (as opposed to being a global var) and has a http.Client for getting public keys

Plan is set up the internal functionality and then use it in the plugin once all done