### PR TITLE
fix: :safety_vest: Audience configuration option should be required

### DIFF
--- a/internal/azurejwtvalidator/config.go
+++ b/internal/azurejwtvalidator/config.go
@@ -6,7 +6,7 @@ type Config struct {
 	PublicKey     string `validate:"required_without=KeysUrl"`
 	KeysUrl       string `validate:"required_without=PublicKey,omitempty,http_url"`
 	Issuer        string `validate:"required,http_url"`
-	Audience      string
+	Audience      string `validate:"required"`
 	Roles         []string
 	MatchAllRoles bool
 }

--- a/internal/azurejwtvalidator/config_test.go
+++ b/internal/azurejwtvalidator/config_test.go
@@ -15,6 +15,15 @@ func TestConfig_validate(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Error:Field validation for 'Issuer' failed on the 'required' tag")
 	})
+	t.Run("expect error if Audience isn't present", func(t *testing.T) {
+		config := Config{
+			KeysUrl: "https://jwks.keys",
+			Issuer:  "https://issuer.test",
+		}
+		err := config.validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Error:Field validation for 'Audience' failed on the 'required' tag")
+	})
 	t.Run("expect Issuer to be a http url string", func(t *testing.T) {
 		config := Config{
 			KeysUrl: "https://jwks.keys",
@@ -26,8 +35,9 @@ func TestConfig_validate(t *testing.T) {
 	})
 	t.Run("expect PublicKey to be optional if KeysUrl is present", func(t *testing.T) {
 		config := Config{
-			KeysUrl: "https://jwks.keys",
-			Issuer:  "https://issuer.test",
+			KeysUrl:  "https://jwks.keys",
+			Issuer:   "https://issuer.test",
+			Audience: "audience1",
 		}
 		err := config.validate()
 		assert.NoError(t, err)
@@ -36,6 +46,7 @@ func TestConfig_validate(t *testing.T) {
 		config := Config{
 			PublicKey: "some public-key",
 			Issuer:    "https://issuer.test",
+			Audience:  "audience1",
 		}
 		err := config.validate()
 		assert.NoError(t, err)


### PR DESCRIPTION
Audience configuration option should be required:
https://learn.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#validate-claims