### PR TITLE
Alex/refactor validate token

### DIFF
--- a/internal/azurejwtvalidator/getpublickeys.go
+++ b/internal/azurejwtvalidator/getpublickeys.go
@@ -15,6 +15,7 @@ import (
 	"github.com/music-tribe/azadjwtvalidation/internal/jwtmodels"
 )
 
+// FIXME: we already have the config on the azjwt instance so we shouldn't need to pass it in here
 func (azjwt *AzureJwtValidator) GetPublicKeys(config *Config) error {
 	err := azjwt.verifyAndSetPublicKey(config.PublicKey)
 	if err != nil {
@@ -109,8 +110,11 @@ func (azjwt *AzureJwtValidator) verifyAndSetPublicKey(publicKey string) error {
 	if pubKey, ok := parsedKey.(*rsa.PublicKey); !ok {
 		return fmt.Errorf("unable to convert RSA public key")
 	} else {
-		// FIXME: should we be generating & storing the kid here?
-		azjwt.rsakeys["config_rsa"] = pubKey
+		kid, err := jwtmodels.GenerateJwkKid(pubKey)
+		if err != nil {
+			return fmt.Errorf("failed to generate JWK kid: %v", err)
+		}
+		azjwt.rsakeys[kid] = pubKey
 	}
 
 	return nil

--- a/internal/azurejwtvalidator/getpublickeys.go
+++ b/internal/azurejwtvalidator/getpublickeys.go
@@ -15,26 +15,25 @@ import (
 	"github.com/music-tribe/azadjwtvalidation/internal/jwtmodels"
 )
 
-// FIXME: we already have the config on the azjwt instance so we shouldn't need to pass it in here
-func (azjwt *AzureJwtValidator) GetPublicKeys(config *Config) error {
-	err := azjwt.verifyAndSetPublicKey(config.PublicKey)
+func (azjwt *AzureJwtValidator) GetPublicKeys() error {
+	err := azjwt.verifyAndSetPublicKey(azjwt.config.PublicKey)
 	if err != nil {
 		return err
 	}
 
-	if strings.TrimSpace(config.KeysUrl) != "" {
+	if strings.TrimSpace(azjwt.config.KeysUrl) != "" {
 		var body jwtmodels.JWKSet
-		resp, err := azjwt.client.Get(config.KeysUrl)
+		resp, err := azjwt.client.Get(azjwt.config.KeysUrl)
 
 		if err != nil {
-			e := fmt.Errorf("failed to load public key from:%v", config.KeysUrl)
+			e := fmt.Errorf("failed to load public key from:%v", azjwt.config.KeysUrl)
 			azjwt.logger.Warn(e.Error())
 			return e
 		}
 		defer resp.Body.Close()
 		bytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			e := fmt.Errorf("failed to read response body from:%v", config.KeysUrl)
+			e := fmt.Errorf("failed to read response body from:%v", azjwt.config.KeysUrl)
 			azjwt.logger.Warn(e.Error())
 			return e
 		}
@@ -55,7 +54,7 @@ func (azjwt *AzureJwtValidator) GetPublicKeys(config *Config) error {
 		keys := body.Keys
 
 		if len(keys) == 0 {
-			e := fmt.Errorf("failed to load public key. No keys found from:%v", config.KeysUrl)
+			e := fmt.Errorf("failed to load public key. No keys found from:%v", azjwt.config.KeysUrl)
 			azjwt.logger.Warn(e.Error())
 			return e
 		}

--- a/internal/azurejwtvalidator/getpublickeys_test.go
+++ b/internal/azurejwtvalidator/getpublickeys_test.go
@@ -146,8 +146,8 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 		configWithInvalidPublicKey := config
 		configWithInvalidPublicKey.PublicKey = "invalid public key"
 
-		azureJwtValidator := NewAzureJwtValidator(config, http.DefaultClient, l)
-		err := azureJwtValidator.GetPublicKeys(&configWithInvalidPublicKey)
+		azureJwtValidator := NewAzureJwtValidator(configWithInvalidPublicKey, http.DefaultClient, l)
+		err := azureJwtValidator.GetPublicKeys()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "public key could not be decoded")
 	})
@@ -166,7 +166,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn("failed to load public key from:https://jwks.keys")
 
-		err := azureJwtValidator.GetPublicKeys(&config)
+		err := azureJwtValidator.GetPublicKeys()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load public key from:")
 	})
@@ -188,7 +188,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn("failed to read response body from:https://jwks.keys")
 
-		err := azureJwtValidator.GetPublicKeys(&config)
+		err := azureJwtValidator.GetPublicKeys()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read response body from:")
 	})
@@ -211,7 +211,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn(fmt.Sprintf("failed to retrieve keys. Response: %s, Body: %s", "Forbidden", "test"))
 
-		err := azureJwtValidator.GetPublicKeys(&config)
+		err := azureJwtValidator.GetPublicKeys()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to retrieve keys.")
 	})
@@ -233,7 +233,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn("failed to unmarshal public keys: invalid character 'e' in literal true (expecting 'r'). Response: , Body: test")
 
-		err := azureJwtValidator.GetPublicKeys(&config)
+		err := azureJwtValidator.GetPublicKeys()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal public keys")
 	})
@@ -261,7 +261,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn("failed to load public key. No keys found from:https://jwks.keys")
 
-		err = azureJwtValidator.GetPublicKeys(&config)
+		err = azureJwtValidator.GetPublicKeys()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load public key")
 	})
@@ -297,7 +297,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn("Error parsing key E:illegal base64 data at input byte 7")
 
-		err = azureJwtValidator.GetPublicKeys(&config)
+		err = azureJwtValidator.GetPublicKeys()
 		// No error returned because we loop over many keys but we need to ensure we don't store the dodgy key in our map
 		assert.NoError(t, err)
 		assert.Empty(t, azureJwtValidator.rsakeys)
@@ -334,7 +334,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 
 		l.EXPECT().Warn("Error decoding key N:illegal base64 data at input byte 3")
 
-		err = azureJwtValidator.GetPublicKeys(&config)
+		err = azureJwtValidator.GetPublicKeys()
 		// No error returned because we loop over many keys but we need to ensure we don't store the dodgy key in our map
 		assert.NoError(t, err)
 		assert.Empty(t, azureJwtValidator.rsakeys)
@@ -369,7 +369,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 			},
 			l)
 
-		err = azureJwtValidator.GetPublicKeys(&config)
+		err = azureJwtValidator.GetPublicKeys()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, azureJwtValidator.rsakeys)
 		assert.Equal(t, pub, azureJwtValidator.rsakeys[kid])
@@ -415,7 +415,7 @@ func TestAzureJwtValidator_GetPublicKeys(t *testing.T) {
 			},
 			l)
 
-		err = azureJwtValidator.GetPublicKeys(&config)
+		err = azureJwtValidator.GetPublicKeys()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, azureJwtValidator.rsakeys)
 		assert.True(t, len(azureJwtValidator.rsakeys) == 2)

--- a/internal/azurejwtvalidator/getpublickeys_test.go
+++ b/internal/azurejwtvalidator/getpublickeys_test.go
@@ -26,6 +26,8 @@ func TestAzureJwtValidator_verifyAndSetPublicKey(t *testing.T) {
 	t.Parallel()
 
 	pub := generatePublicKey(t)
+	kid, err := jwtmodels.GenerateJwkKid(pub)
+	require.NoError(t, err)
 
 	config := Config{
 		KeysUrl:       "https://jwks.keys",
@@ -112,7 +114,7 @@ and some more`)
 		err = azureJwtValidator.verifyAndSetPublicKey(string(pubPEM))
 		assert.NoError(t, err)
 		assert.NotNil(t, azureJwtValidator.rsakeys)
-		assert.Equal(t, pub, azureJwtValidator.rsakeys["config_rsa"])
+		assert.Equal(t, pub, azureJwtValidator.rsakeys[kid])
 	})
 }
 

--- a/internal/azurejwtvalidator/validatetoken.go
+++ b/internal/azurejwtvalidator/validatetoken.go
@@ -1,0 +1,56 @@
+package azurejwtvalidator
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/music-tribe/azadjwtvalidation/internal/jwtmodels"
+)
+
+func (azjwt *AzureJwtValidator) ValidateToken(token *jwtmodels.AzureJwt) error {
+	hash := sha256.Sum256(token.RawToken)
+
+	if _, ok := azjwt.rsakeys[token.Header.Kid]; !ok {
+		return errors.New("invalid public key")
+	}
+
+	err := rsa.VerifyPKCS1v15(azjwt.rsakeys[token.Header.Kid], crypto.SHA256, hash[:], token.Signature)
+	if err != nil {
+		return err
+	}
+
+	if err := azjwt.verifyToken(token); err != nil {
+		return err
+	}
+
+	var claims jwtmodels.Claims
+	if err := json.Unmarshal(token.RawPayload, &claims); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (azjwt *AzureJwtValidator) verifyToken(jwtToken *jwtmodels.AzureJwt) error {
+	tokenExpiration, err := jwtToken.Payload.Exp.Int64()
+	if err != nil {
+		return err
+	}
+
+	if tokenExpiration < time.Now().Unix() {
+		azjwt.logger.Warn(fmt.Sprintf("Token has expired: %s", time.Unix(tokenExpiration, 0).UTC().Format(time.RFC3339)))
+		return errors.New("token is expired")
+	}
+
+	err = jwtToken.Payload.Validate(azjwt.config.Audience, azjwt.config.Issuer, azjwt.config.Roles, azjwt.config.MatchAllRoles, azjwt.logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/azurejwtvalidator/validatetoken.go
+++ b/internal/azurejwtvalidator/validatetoken.go
@@ -28,6 +28,7 @@ func (azjwt *AzureJwtValidator) ValidateToken(token *jwtmodels.AzureJwt) error {
 		return err
 	}
 
+	// FIXME: haven't we already go the Claims in the Payload?
 	var claims jwtmodels.Claims
 	if err := json.Unmarshal(token.RawPayload, &claims); err != nil {
 		return err

--- a/internal/azurejwtvalidator/validatetoken_test.go
+++ b/internal/azurejwtvalidator/validatetoken_test.go
@@ -1,0 +1,158 @@
+package azurejwtvalidator
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/music-tribe/azadjwtvalidation/internal/jwtmodels"
+	"github.com/music-tribe/azadjwtvalidation/internal/logger"
+)
+
+func TestAzureJwtValidator_verifyToken(t *testing.T) {
+	t.Parallel()
+
+	l := logger.NewStdLog("warn")
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pub := &privateKey.PublicKey
+
+	type fields struct {
+		config  Config
+		client  *http.Client
+		logger  logger.Logger
+		rsakeys map[string]*rsa.PublicKey
+	}
+	type args struct {
+		jwtToken *jwtmodels.AzureJwt
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "expect invalid if audience is wrong",
+			fields: fields{
+				config: Config{
+					Audience: "test-audience",
+					Issuer:   "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+					Roles:    []string{"Test.Role.1", "Test.Role.2"},
+				},
+				client: http.DefaultClient,
+				logger: l,
+				rsakeys: map[string]*rsa.PublicKey{
+					"test-key-id": pub,
+				},
+			},
+			args: args{
+				jwtToken: generateTestJwt(t,
+					time.Now().Add(1*time.Hour),
+					[]string{"Test.Role.1", "Test.Role.2"},
+					"wrong-audience",
+					"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+					privateKey),
+			},
+			wantErr:    true,
+			wantErrMsg: "token audience is wrong",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			azjwt := &AzureJwtValidator{
+				config:  tt.fields.config,
+				client:  tt.fields.client,
+				logger:  tt.fields.logger,
+				rsakeys: tt.fields.rsakeys,
+			}
+			var err error
+			if err = azjwt.verifyToken(tt.args.jwtToken); (err != nil) != tt.wantErr {
+				t.Errorf("AzureJwtValidator.verifyToken() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.wantErrMsg, err.Error(), "Expected error message does not match")
+			}
+		})
+	}
+}
+
+type JwtClaim struct {
+	Roles []string
+	jwt.RegisteredClaims
+}
+
+func generateTestJwt(t *testing.T, expiresAt time.Time, roles []string, audience string, issuer string, privKey *rsa.PrivateKey) *jwtmodels.AzureJwt {
+	testClaims := JwtClaim{
+		Roles: roles,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    issuer,
+			Audience:  jwt.ClaimStrings{audience},
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Subject:   "test-subject",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, testClaims)
+	token.Header["kid"] = publicKeyToBytes(t, &privKey.PublicKey)
+
+	signedString, errSignedString := token.SignedString(privKey)
+	require.NoError(t, errSignedString)
+	token.Signature = signedString
+
+	return convertToAzureJwt(t, signedString, &privKey.PublicKey)
+}
+
+func convertToAzureJwt(t *testing.T, tokenString string, pub *rsa.PublicKey) *jwtmodels.AzureJwt {
+	token, err := jwt.ParseWithClaims(tokenString, &JwtClaim{}, func(token *jwt.Token) (any, error) {
+		return pub, nil
+	})
+	require.NoError(t, err)
+	claims, ok := token.Claims.(*JwtClaim)
+	require.True(t, ok)
+
+	aud := ""
+	if len(claims.Audience) != 0 {
+		aud = claims.Audience[0] // Use the first audience if multiple are present
+	}
+	azureJwt := &jwtmodels.AzureJwt{
+		Header: jwtmodels.AzureJwtHeader{Alg: "RS256", Kid: token.Header["kid"].(string), Typ: "JWT"},
+		Payload: jwtmodels.Claims{
+			Iat:   json.Number(strconv.FormatInt(claims.IssuedAt.Unix(), 10)),
+			Exp:   json.Number(strconv.FormatInt(claims.ExpiresAt.Unix(), 10)),
+			Iss:   claims.Issuer,
+			Aud:   aud,
+			Sub:   claims.Subject,
+			Roles: claims.Roles,
+		},
+		Signature:  []byte(token.Signature),
+		RawToken:   []byte(tokenString),
+		RawPayload: []byte(token.Raw),
+	}
+
+	return azureJwt
+}
+
+func publicKeyToBytes(t *testing.T, pub *rsa.PublicKey) []byte {
+	pubASN1, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+
+	pubBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: pubASN1,
+	})
+
+	return pubBytes
+}


### PR DESCRIPTION
Adding validate and verify token functionality to the internal/azurejwtvalidator package and adding a bunch of tests