### PR TITLE
Alex/non positive interval for new ticker

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -10,6 +10,7 @@ testData:
   roles: 
     - Test.Role.1
     - Test.Role.2
+  loglevel: "DEBUG"
   logheaders:
     - X-Request-Id
     - Host

--- a/internal/azurejwtvalidator/scheduleupdatekeys.go
+++ b/internal/azurejwtvalidator/scheduleupdatekeys.go
@@ -6,8 +6,14 @@ import (
 	"time"
 )
 
+// ScheduleUpdateKeysAsync starts a goroutine that periodically updates the public keys used for JWT validation.
+func (azjwt *AzureJwtValidator) ScheduleUpdateKeysAsync(ctx context.Context) {
+	azjwt.logger.Info(fmt.Sprintf("Scheduling periodic update of public keys every %d minutes", azjwt.config.UpdateKeysEveryMinutes))
+	go azjwt.scheduleUpdateKeys(ctx, time.NewTicker(time.Duration(azjwt.config.UpdateKeysEveryMinutes)*time.Minute))
+}
+
 // Periodically updates the public keys used for JWT validation.
-func (azjwt *AzureJwtValidator) ScheduleUpdateKeys(ctx context.Context, ticker *time.Ticker) {
+func (azjwt *AzureJwtValidator) scheduleUpdateKeys(ctx context.Context, ticker *time.Ticker) {
 	defer ticker.Stop()
 
 	for {
@@ -17,7 +23,7 @@ func (azjwt *AzureJwtValidator) ScheduleUpdateKeys(ctx context.Context, ticker *
 		case <-ticker.C:
 			err := azjwt.GetPublicKeysWithOptionalBackoffRetry(ctx)
 			if err != nil {
-				azjwt.logger.Warn(fmt.Sprintf("ScheduleUpdateKeys: %v", err))
+				azjwt.logger.Warn(fmt.Sprintf("scheduleUpdateKeys: %v", err))
 			}
 		}
 	}

--- a/internal/azurejwtvalidator/scheduleupdatekeys_test.go
+++ b/internal/azurejwtvalidator/scheduleupdatekeys_test.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestAzureJwtValidator_ScheduleUpdateKeys(t *testing.T) {
+func TestAzureJwtValidator_scheduleUpdateKeys(t *testing.T) {
 	t.Parallel()
 
 	t.Run("expect to return if context is done", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestAzureJwtValidator_ScheduleUpdateKeys(t *testing.T) {
 		defer cancel()
 		ticker := time.NewTicker(time.Duration(azjwt.config.UpdateKeysEveryMinutes) * time.Minute)
 
-		azjwt.ScheduleUpdateKeys(ctx, ticker)
+		azjwt.scheduleUpdateKeys(ctx, ticker)
 	})
 
 	t.Run("expect to get public keys", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestAzureJwtValidator_ScheduleUpdateKeys(t *testing.T) {
 		defer cancel()
 		ticker := time.NewTicker(100 * time.Millisecond)
 
-		azjwt.ScheduleUpdateKeys(ctx, ticker)
+		azjwt.scheduleUpdateKeys(ctx, ticker)
 		assert.True(t, azjwt.rsakeys.Len() > 0, "expected public keys to be loaded")
 	})
 
@@ -114,13 +114,13 @@ func TestAzureJwtValidator_ScheduleUpdateKeys(t *testing.T) {
 
 		ml.EXPECT().Warn("failed to retrieve keys. Response: , Body: ").AnyTimes()
 		ml.EXPECT().Warn("failed to get public keys after 0 retries: failed to retrieve keys. Response: , Body: ").AnyTimes()
-		ml.EXPECT().Warn("ScheduleUpdateKeys: failed to retrieve keys. Response: , Body: ").AnyTimes()
+		ml.EXPECT().Warn("scheduleUpdateKeys: failed to retrieve keys. Response: , Body: ").AnyTimes()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 		defer cancel()
 		ticker := time.NewTicker(100 * time.Millisecond)
 
-		azjwt.ScheduleUpdateKeys(ctx, ticker)
+		azjwt.scheduleUpdateKeys(ctx, ticker)
 		assert.True(t, azjwt.rsakeys.Len() == 0, "expected no public keys to be loaded")
 	})
 
@@ -149,19 +149,19 @@ func TestAzureJwtValidator_ScheduleUpdateKeys(t *testing.T) {
 
 		ml.EXPECT().Warn(gomock.Any()).AnyTimes()
 		ml.EXPECT().Warn(gomock.Any()).AnyTimes()
-		ml.EXPECT().Warn("ScheduleUpdateKeys: failed to get public keys after 1 retries: failed to retrieve keys. Response: , Body: ").AnyTimes()
+		ml.EXPECT().Warn("scheduleUpdateKeys: failed to get public keys after 1 retries: failed to retrieve keys. Response: , Body: ").AnyTimes()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
 		defer cancel()
 		ticker := time.NewTicker(500 * time.Millisecond)
 
-		azjwt.ScheduleUpdateKeys(ctx, ticker)
+		azjwt.scheduleUpdateKeys(ctx, ticker)
 		assert.True(t, azjwt.rsakeys.Len() == 0, "expected no public keys to be loaded")
 	})
 }
 
 // Test we preserve public keys whilst periodically updating them so that token validation does not fail with 403s due to missing keys.
-func TestAzureJwtValidator_ScheduleUpdateKeysPreservesRsaKeys(t *testing.T) {
+func TestAzureJwtValidator_scheduleUpdateKeysPreservesRsaKeys(t *testing.T) {
 	t.Parallel()
 
 	t.Run("should not drop public keys during key updates", func(t *testing.T) {
@@ -228,11 +228,11 @@ func TestAzureJwtValidator_ScheduleUpdateKeysPreservesRsaKeys(t *testing.T) {
 		go server.Serve(ln)
 		defer server.Close()
 
-		// Start ScheduleUpdateKeys in background
+		// Start scheduleUpdateKeys in background
 		ctx, cancel := context.WithCancel(context.Background())
 		ticker := time.NewTicker(50 * time.Millisecond)
 		defer ticker.Stop()
-		go azjwt.ScheduleUpdateKeys(ctx, ticker)
+		go azjwt.scheduleUpdateKeys(ctx, ticker)
 
 		// Generate a valid JWT signed with the private key
 		token := generateTestJwt(t,
@@ -324,11 +324,11 @@ func TestAzureJwtValidator_ScheduleUpdateKeysPreservesRsaKeys(t *testing.T) {
 		go server.Serve(ln)
 		defer server.Close()
 
-		// Start ScheduleUpdateKeys in background
+		// Start scheduleUpdateKeys in background
 		ctx, cancel := context.WithCancel(context.Background())
 		ticker := time.NewTicker(50 * time.Millisecond)
 		defer ticker.Stop()
-		go azjwt.ScheduleUpdateKeys(ctx, ticker)
+		go azjwt.scheduleUpdateKeys(ctx, ticker)
 
 		// Generate an invalid JWT (e.g., with wrong audience)
 		token := generateTestJwt(t,

--- a/plugin.go
+++ b/plugin.go
@@ -68,7 +68,7 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		return nil, err
 	}
 
-	go validator.ScheduleUpdateKeys(ctx, time.NewTicker(time.Duration(config.UpdateKeysEveryMinutes)*time.Minute))
+	validator.ScheduleUpdateKeysAsync(ctx)
 
 	plugin := &AzureJwtPlugin{
 		next:      next,


### PR DESCRIPTION
Fixes #39 

This pull request introduces a new asynchronous method for scheduling periodic updates of public keys in the `AzureJwtValidator` class, refactors existing code to align with this change, and makes minor configuration updates. The most significant changes include the addition of the `ScheduleUpdateKeysAsync` method, the refactoring of the `ScheduleUpdateKeys` method to a private function, and updates to the corresponding tests.

### Refactoring and Asynchronous Updates:

* [`internal/azurejwtvalidator/scheduleupdatekeys.go`](diffhunk://#diff-06d0c197140dade6e344a70f896b2065869a3367c663357d8d50cff77440cd58R9-R16): Added `ScheduleUpdateKeysAsync`, a public method that starts a goroutine for periodic updates of public keys. Refactored the existing `ScheduleUpdateKeys` method into a private function named `scheduleUpdateKeys`. [[1]](diffhunk://#diff-06d0c197140dade6e344a70f896b2065869a3367c663357d8d50cff77440cd58R9-R16) [[2]](diffhunk://#diff-06d0c197140dade6e344a70f896b2065869a3367c663357d8d50cff77440cd58L20-R26)

* [`plugin.go`](diffhunk://#diff-8c9bf6ac6a298e3c093386b6f36e0cade8724ef38e50f80c7ecf19cd6e562471L71-R71): Updated the plugin initialization to use the new `ScheduleUpdateKeysAsync` method instead of directly invoking `ScheduleUpdateKeys`.

### Test Updates:

* [`internal/azurejwtvalidator/scheduleupdatekeys_test.go`](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L23-R23): Updated all test cases to use the private `scheduleUpdateKeys` method instead of the public `ScheduleUpdateKeys` method. Adjusted logging expectations to match the new method name. [[1]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L23-R23) [[2]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L44-R44) [[3]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L89-R89) [[4]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L117-R123) [[5]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L152-R164) [[6]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L231-R235) [[7]](diffhunk://#diff-87dffe4e81f657eb0c9f9648d369d3be0c52fdf443768b403237ea5986a60195L327-R331)

### Configuration Changes:

* [`.traefik.yml`](diffhunk://#diff-df51b558f691f7111a18769218f357886dab24ae1c8485285a4d6175f16c2175R13): Added a new `loglevel` configuration option with a value of `"DEBUG"`.